### PR TITLE
Make CraftTweaker support use CTIngredient

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,6 @@ forge_version=36.2.0
 cofh_core_version=1.3.1.+
 
 jei_version=7.7.1.116
-crt_version=7.1.0.357
+crt_version=7.1.2.414
 patchouli_version=1.16.4-53
 curios_version=1.16.5-4.0.5.2

--- a/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTCompressionManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTCompressionManager.java
@@ -29,7 +29,7 @@ public class CRTCompressionManager implements IRecipeManager {
     }
 
     @Override
-    public void removeRecipe(IItemStack output) {
+    public void removeRecipe(IIngredient output) {
 
         throw new IllegalArgumentException("Compression Fuel only works with fluids! Please provide an IFluidStack");
     }

--- a/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTCompressionManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTCompressionManager.java
@@ -25,7 +25,7 @@ public class CRTCompressionManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         CompressionFuel recipe = new CRTFuel(resourceLocation, energy).fluid(ingredient).fuel(CompressionFuel::new);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTCompressionManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTCompressionManager.java
@@ -6,8 +6,8 @@ import cofh.thermal.lib.compat.crt.actions.ActionRemoveThermalFuelByOutput;
 import cofh.thermal.lib.compat.crt.base.CRTFuel;
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
-import com.blamejared.crafttweaker.api.fluid.IFluidStack;
-import com.blamejared.crafttweaker.api.item.IItemStack;
+import com.blamejared.crafttweaker.api.fluid.*;
+import com.blamejared.crafttweaker.api.item.*;
 import com.blamejared.crafttweaker.api.managers.IRecipeManager;
 import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
 import net.minecraft.item.crafting.IRecipeType;
@@ -19,7 +19,7 @@ import org.openzen.zencode.java.ZenCodeType;
 public class CRTCompressionManager implements IRecipeManager {
 
     @ZenCodeType.Method
-    public void addFuel(String name, IFluidStack ingredient, int energy) {
+    public void addFuel(String name, CTFluidIngredient ingredient, int energy) {
 
         name = fixRecipeName(name);
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);

--- a/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTDisenchantmentManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTDisenchantmentManager.java
@@ -25,7 +25,7 @@ public class CRTDisenchantmentManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         DisenchantmentFuel recipe = new CRTFuel(resourceLocation, energy).item(ingredient).fuel(DisenchantmentFuel::new);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTGourmandManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTGourmandManager.java
@@ -25,7 +25,7 @@ public class CRTGourmandManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         GourmandFuel recipe = new CRTFuel(resourceLocation, energy).item(ingredient).fuel(GourmandFuel::new);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTLapidaryManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTLapidaryManager.java
@@ -25,7 +25,7 @@ public class CRTLapidaryManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         LapidaryFuel recipe = new CRTFuel(resourceLocation, energy).item(ingredient).fuel(LapidaryFuel::new);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTMagmaticManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTMagmaticManager.java
@@ -29,7 +29,7 @@ public class CRTMagmaticManager implements IRecipeManager {
     }
 
     @Override
-    public void removeRecipe(IItemStack output) {
+    public void removeRecipe(IIngredient output) {
 
         throw new IllegalArgumentException("Magmatic Fuel only works with fluids! Please provide an IFluidStack");
     }

--- a/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTMagmaticManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTMagmaticManager.java
@@ -25,7 +25,7 @@ public class CRTMagmaticManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         MagmaticFuel recipe = new CRTFuel(resourceLocation, energy).fluid(ingredient).fuel(MagmaticFuel::new);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTMagmaticManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTMagmaticManager.java
@@ -6,8 +6,8 @@ import cofh.thermal.lib.compat.crt.actions.ActionRemoveThermalFuelByOutput;
 import cofh.thermal.lib.compat.crt.base.CRTFuel;
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
-import com.blamejared.crafttweaker.api.fluid.IFluidStack;
-import com.blamejared.crafttweaker.api.item.IItemStack;
+import com.blamejared.crafttweaker.api.fluid.*;
+import com.blamejared.crafttweaker.api.item.*;
 import com.blamejared.crafttweaker.api.managers.IRecipeManager;
 import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
 import net.minecraft.item.crafting.IRecipeType;
@@ -19,7 +19,7 @@ import org.openzen.zencode.java.ZenCodeType;
 public class CRTMagmaticManager implements IRecipeManager {
 
     @ZenCodeType.Method
-    public void addFuel(String name, IFluidStack ingredient, int energy) {
+    public void addFuel(String name, CTFluidIngredient ingredient, int energy) {
 
         name = fixRecipeName(name);
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);

--- a/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTNumismaticManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTNumismaticManager.java
@@ -25,7 +25,7 @@ public class CRTNumismaticManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         NumismaticFuel recipe = new CRTFuel(resourceLocation, energy).item(ingredient).fuel(NumismaticFuel::new);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTStirlingManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/dynamo/CRTStirlingManager.java
@@ -25,7 +25,7 @@ public class CRTStirlingManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         StirlingFuel recipe = new CRTFuel(resourceLocation, energy).item(ingredient).fuel(StirlingFuel::new);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTBottlerManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTBottlerManager.java
@@ -26,7 +26,7 @@ public class CRTBottlerManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         CRTRecipe crtRecipe = new CRTRecipe(resourceLocation).energy(energy).input(ingredient).input(fluidInput).output(output);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(BottlerRecipe::new), ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(BottlerRecipe::new)));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTBottlerManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTBottlerManager.java
@@ -6,7 +6,7 @@ import cofh.thermal.lib.compat.crt.actions.ActionRemoveThermalRecipeByOutput;
 import cofh.thermal.lib.compat.crt.base.CRTRecipe;
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
-import com.blamejared.crafttweaker.api.fluid.IFluidStack;
+import com.blamejared.crafttweaker.api.fluid.*;
 import com.blamejared.crafttweaker.api.item.IIngredient;
 import com.blamejared.crafttweaker.api.item.IItemStack;
 import com.blamejared.crafttweaker.api.managers.IRecipeManager;
@@ -20,7 +20,7 @@ import org.openzen.zencode.java.ZenCodeType;
 public class CRTBottlerManager implements IRecipeManager {
 
     @ZenCodeType.Method
-    public void addRecipe(String name, IItemStack output, IIngredient ingredient, IFluidStack fluidInput, int energy) {
+    public void addRecipe(String name, IItemStack output, IIngredient ingredient, CTFluidIngredient fluidInput, int energy) {
 
         name = fixRecipeName(name);
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTBrewerManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTBrewerManager.java
@@ -26,7 +26,7 @@ public class CRTBrewerManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         CRTRecipe crtRecipe = new CRTRecipe(resourceLocation).energy(energy).input(ingredient).input(fluidInput).output(output);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(BrewerRecipe::new), ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(BrewerRecipe::new)));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTBrewerManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTBrewerManager.java
@@ -6,7 +6,7 @@ import cofh.thermal.lib.compat.crt.actions.ActionRemoveThermalRecipeByOutput;
 import cofh.thermal.lib.compat.crt.base.CRTRecipe;
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
-import com.blamejared.crafttweaker.api.fluid.IFluidStack;
+import com.blamejared.crafttweaker.api.fluid.*;
 import com.blamejared.crafttweaker.api.item.IIngredient;
 import com.blamejared.crafttweaker.api.item.IItemStack;
 import com.blamejared.crafttweaker.api.managers.IRecipeManager;
@@ -20,7 +20,7 @@ import org.openzen.zencode.java.ZenCodeType;
 public class CRTBrewerManager implements IRecipeManager {
 
     @ZenCodeType.Method
-    public void addRecipe(String name, IFluidStack output, IIngredient ingredient, IFluidStack fluidInput, int energy) {
+    public void addRecipe(String name, IFluidStack output, IIngredient ingredient, CTFluidIngredient fluidInput, int energy) {
 
         name = fixRecipeName(name);
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
@@ -36,7 +36,7 @@ public class CRTBrewerManager implements IRecipeManager {
     }
 
     @Override
-    public void removeRecipe(IItemStack output) {
+    public void removeRecipe(IIngredient output) {
 
         throw new IllegalArgumentException("The Brewer only outputs fluids! Please provide an IFluidStack");
     }

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTBrewerManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTBrewerManager.java
@@ -6,6 +6,7 @@ import cofh.thermal.lib.compat.crt.actions.ActionRemoveThermalRecipeByOutput;
 import cofh.thermal.lib.compat.crt.base.CRTRecipe;
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker.api.fluid.CTFluidIngredient;
 import com.blamejared.crafttweaker.api.fluid.IFluidStack;
 import com.blamejared.crafttweaker.api.item.IIngredient;
 import com.blamejared.crafttweaker.api.item.IItemStack;
@@ -20,7 +21,7 @@ import org.openzen.zencode.java.ZenCodeType;
 public class CRTBrewerManager implements IRecipeManager {
 
     @ZenCodeType.Method
-    public void addRecipe(String name, IFluidStack output, IIngredient ingredient, IFluidStack fluidInput, int energy) {
+    public void addRecipe(String name, IFluidStack output, IIngredient ingredient, CTFluidIngredient fluidInput, int energy) {
 
         name = fixRecipeName(name);
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTBrewerManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTBrewerManager.java
@@ -6,7 +6,7 @@ import cofh.thermal.lib.compat.crt.actions.ActionRemoveThermalRecipeByOutput;
 import cofh.thermal.lib.compat.crt.base.CRTRecipe;
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
-import com.blamejared.crafttweaker.api.fluid.*;
+import com.blamejared.crafttweaker.api.fluid.IFluidStack;
 import com.blamejared.crafttweaker.api.item.IIngredient;
 import com.blamejared.crafttweaker.api.item.IItemStack;
 import com.blamejared.crafttweaker.api.managers.IRecipeManager;
@@ -20,7 +20,7 @@ import org.openzen.zencode.java.ZenCodeType;
 public class CRTBrewerManager implements IRecipeManager {
 
     @ZenCodeType.Method
-    public void addRecipe(String name, IFluidStack output, IIngredient ingredient, CTFluidIngredient fluidInput, int energy) {
+    public void addRecipe(String name, IFluidStack output, IIngredient ingredient, IFluidStack fluidInput, int energy) {
 
         name = fixRecipeName(name);
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTCentrifugeManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTCentrifugeManager.java
@@ -27,7 +27,7 @@ public class CRTCentrifugeManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         CRTRecipe crtRecipe = new CRTRecipe(resourceLocation).energy(energy).input(ingredient).output(outputs).output(outputFluid);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(CentrifugeRecipe::new), ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(CentrifugeRecipe::new)));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTChillerManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTChillerManager.java
@@ -26,7 +26,7 @@ public class CRTChillerManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         CRTRecipe crtRecipe = new CRTRecipe(resourceLocation).energy(energy).input(ingredient).input(inputFluid).output(output);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(ChillerRecipe::new), ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(ChillerRecipe::new)));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTChillerManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTChillerManager.java
@@ -6,7 +6,7 @@ import cofh.thermal.lib.compat.crt.actions.ActionRemoveThermalRecipeByOutput;
 import cofh.thermal.lib.compat.crt.base.CRTRecipe;
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
-import com.blamejared.crafttweaker.api.fluid.IFluidStack;
+import com.blamejared.crafttweaker.api.fluid.*;
 import com.blamejared.crafttweaker.api.item.IIngredient;
 import com.blamejared.crafttweaker.api.item.IItemStack;
 import com.blamejared.crafttweaker.api.managers.IRecipeManager;
@@ -20,7 +20,7 @@ import org.openzen.zencode.java.ZenCodeType;
 public class CRTChillerManager implements IRecipeManager {
 
     @ZenCodeType.Method
-    public void addRecipe(String name, IItemStack output, IIngredient ingredient, IFluidStack inputFluid, int energy) {
+    public void addRecipe(String name, IItemStack output, IIngredient ingredient, CTFluidIngredient inputFluid, int energy) {
 
         name = fixRecipeName(name);
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTCrucibleManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTCrucibleManager.java
@@ -26,7 +26,7 @@ public class CRTCrucibleManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         CRTRecipe crtRecipe = new CRTRecipe(resourceLocation).energy(energy).input(ingredient).output(output);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(CrucibleRecipe::new), ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(CrucibleRecipe::new)));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTCrucibleManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTCrucibleManager.java
@@ -36,7 +36,7 @@ public class CRTCrucibleManager implements IRecipeManager {
     }
 
     @Override
-    public void removeRecipe(IItemStack output) {
+    public void removeRecipe(IIngredient output) {
 
         throw new IllegalArgumentException("The Crucible only outputs fluids! Please provide an IFluidStack");
     }

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTFurnaceManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTFurnaceManager.java
@@ -25,7 +25,7 @@ public class CRTFurnaceManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         CRTRecipe crtRecipe = new CRTRecipe(resourceLocation).energy(energy).input(ingredient).output(output).experience(experience);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(FurnaceRecipe::new), ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(FurnaceRecipe::new)));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTInsolatorCatalystManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTInsolatorCatalystManager.java
@@ -25,7 +25,7 @@ public class CRTInsolatorCatalystManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         InsolatorCatalyst catalyst = new CRTCatalyst(resourceLocation, ingredient, primaryMod, secondaryMod, energyMod, minChance, useChance).catalyst(InsolatorCatalyst::new);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, catalyst, ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, catalyst));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTInsolatorManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTInsolatorManager.java
@@ -6,10 +6,12 @@ import cofh.thermal.lib.compat.crt.actions.ActionRemoveThermalRecipeByOutput;
 import cofh.thermal.lib.compat.crt.base.CRTRecipe;
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker.api.fluid.CTFluidIngredient;
 import com.blamejared.crafttweaker.api.item.IIngredient;
 import com.blamejared.crafttweaker.api.item.IItemStack;
 import com.blamejared.crafttweaker.api.managers.IRecipeManager;
 import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
+import com.blamejared.crafttweaker.impl.fluid.MCFluidStack;
 import com.blamejared.crafttweaker.impl.item.MCWeightedItemStack;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.item.crafting.IRecipeType;
@@ -27,7 +29,7 @@ public class CRTInsolatorManager implements IRecipeManager {
         name = fixRecipeName(name);
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
-        CRTRecipe crtRecipe = new CRTRecipe(resourceLocation).energy(energy).input(ingredient).input(new FluidStack(Fluids.WATER, fluidAmount)).output(outputs);
+        CRTRecipe crtRecipe = new CRTRecipe(resourceLocation).energy(energy).input(ingredient).input(new CTFluidIngredient.FluidStackIngredient(new MCFluidStack(new FluidStack(Fluids.WATER, fluidAmount)))).output(outputs);
         CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(InsolatorRecipe::new)));
     }
 

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTInsolatorManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTInsolatorManager.java
@@ -28,7 +28,7 @@ public class CRTInsolatorManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         CRTRecipe crtRecipe = new CRTRecipe(resourceLocation).energy(energy).input(ingredient).input(new FluidStack(Fluids.WATER, fluidAmount)).output(outputs);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(InsolatorRecipe::new), ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(InsolatorRecipe::new)));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTPressManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTPressManager.java
@@ -27,7 +27,7 @@ public class CRTPressManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         CRTRecipe crtRecipe = new CRTRecipe(resourceLocation).energy(energy).input(ingredients).output(outputs).output(outputFluid);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(PressRecipe::new), ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(PressRecipe::new)));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTPulverizerCatalystManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTPulverizerCatalystManager.java
@@ -25,7 +25,7 @@ public class CRTPulverizerCatalystManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         PulverizerCatalyst catalyst = new CRTCatalyst(resourceLocation, ingredient, primaryMod, secondaryMod, energyMod, minChance, useChance).catalyst(PulverizerCatalyst::new);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, catalyst, ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, catalyst));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTPulverizerManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTPulverizerManager.java
@@ -26,7 +26,7 @@ public class CRTPulverizerManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         CRTRecipe crtRecipe = new CRTRecipe(resourceLocation).energy(energy).input(ingredient).output(outputs).experience(experience);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(PulverizerRecipe::new), ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(PulverizerRecipe::new)));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTPyrolyzerManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTPyrolyzerManager.java
@@ -27,7 +27,7 @@ public class CRTPyrolyzerManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         CRTRecipe crtRecipe = new CRTRecipe(resourceLocation).energy(energy).input(ingredient).output(outputs).output(outputFluid);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(PyrolyzerRecipe::new), ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(PyrolyzerRecipe::new)));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTRefineryManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTRefineryManager.java
@@ -26,7 +26,7 @@ public class CRTRefineryManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         CRTRecipe crtRecipe = new CRTRecipe(resourceLocation).energy(energy).input(inputFluid).output(fluidsOutput).output(itemOutput);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(RefineryRecipe::new), ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(RefineryRecipe::new)));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTRefineryManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTRefineryManager.java
@@ -6,7 +6,7 @@ import cofh.thermal.lib.compat.crt.actions.ActionRemoveThermalRecipeByOutput;
 import cofh.thermal.lib.compat.crt.base.CRTRecipe;
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
-import com.blamejared.crafttweaker.api.fluid.IFluidStack;
+import com.blamejared.crafttweaker.api.fluid.*;
 import com.blamejared.crafttweaker.api.item.IItemStack;
 import com.blamejared.crafttweaker.api.managers.IRecipeManager;
 import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
@@ -20,7 +20,7 @@ import org.openzen.zencode.java.ZenCodeType;
 public class CRTRefineryManager implements IRecipeManager {
 
     @ZenCodeType.Method
-    public void addRecipe(String name, MCWeightedItemStack itemOutput, IFluidStack[] fluidsOutput, IFluidStack inputFluid, int energy) {
+    public void addRecipe(String name, MCWeightedItemStack itemOutput, IFluidStack[] fluidsOutput, CTFluidIngredient inputFluid, int energy) {
 
         name = fixRecipeName(name);
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTSawmillManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTSawmillManager.java
@@ -26,7 +26,7 @@ public class CRTSawmillManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         CRTRecipe crtRecipe = new CRTRecipe(resourceLocation).energy(energy).input(ingredient).output(outputs);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(SawmillRecipe::new), ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(SawmillRecipe::new)));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTSmelterCatalystManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTSmelterCatalystManager.java
@@ -25,7 +25,7 @@ public class CRTSmelterCatalystManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         SmelterCatalyst catalyst = new CRTCatalyst(resourceLocation, ingredient, primaryMod, secondaryMod, energyMod, minChance, useChance).catalyst(SmelterCatalyst::new);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, catalyst, ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, catalyst));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/core/compat/crt/machine/CRTSmelterManager.java
+++ b/src/main/java/cofh/thermal/core/compat/crt/machine/CRTSmelterManager.java
@@ -26,7 +26,7 @@ public class CRTSmelterManager implements IRecipeManager {
         ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
 
         CRTRecipe crtRecipe = new CRTRecipe(resourceLocation).energy(energy).input(ingredients).output(outputs).experience(experience);
-        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(SmelterRecipe::new), ""));
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, crtRecipe.recipe(SmelterRecipe::new)));
     }
 
     @Override

--- a/src/main/java/cofh/thermal/lib/compat/crt/base/CRTFuel.java
+++ b/src/main/java/cofh/thermal/lib/compat/crt/base/CRTFuel.java
@@ -2,7 +2,7 @@ package cofh.thermal.lib.compat.crt.base;
 
 import cofh.lib.fluid.FluidIngredient;
 import cofh.thermal.lib.util.recipes.ThermalFuel;
-import com.blamejared.crafttweaker.api.fluid.IFluidStack;
+import com.blamejared.crafttweaker.api.fluid.*;
 import com.blamejared.crafttweaker.api.item.IIngredient;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.ResourceLocation;
@@ -29,7 +29,13 @@ public class CRTFuel {
         this.item = Collections.singletonList(item.asVanillaIngredient());
         return this;
     }
-
+    
+    public CRTFuel fluid(CTFluidIngredient fluid) {
+        
+        this.fluid = Collections.singletonList(CRTHelper.mapFluidIngredient(fluid));
+        return this;
+    }
+    
     public CRTFuel fluid(IFluidStack fluid) {
 
         this.fluid = Collections.singletonList(FluidIngredient.of(fluid.getInternal()));

--- a/src/main/java/cofh/thermal/lib/compat/crt/base/CRTHelper.java
+++ b/src/main/java/cofh/thermal/lib/compat/crt/base/CRTHelper.java
@@ -1,0 +1,22 @@
+package cofh.thermal.lib.compat.crt.base;
+
+import cofh.lib.fluid.FluidIngredient;
+import com.blamejared.crafttweaker.api.fluid.CTFluidIngredient;
+import net.minecraftforge.fluids.FluidStack;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+public class CRTHelper {
+    
+    /**
+     * Maps a {@link CTFluidIngredient} to a {@link FluidIngredient}.
+     *
+     * @param ingredient The ingredient to map.
+     *
+     * @return A {@link FluidIngredient} representation of the given {@link CTFluidIngredient}.
+     */
+    public static FluidIngredient mapFluidIngredient(CTFluidIngredient ingredient) {
+        return ingredient.mapTo(FluidIngredient::of, FluidIngredient::of, compound -> compound.reduce((first, second) -> FluidIngredient.of(Stream.concat(Arrays.stream(first.getFluids()), Arrays.stream(second.getFluids())))).orElseThrow(() -> new RuntimeException("Error while mapping compound fluid ingredients!")));
+    }
+}

--- a/src/main/java/cofh/thermal/lib/compat/crt/base/CRTRecipe.java
+++ b/src/main/java/cofh/thermal/lib/compat/crt/base/CRTRecipe.java
@@ -2,7 +2,7 @@ package cofh.thermal.lib.compat.crt.base;
 
 import cofh.lib.fluid.FluidIngredient;
 import cofh.thermal.lib.util.recipes.ThermalRecipe;
-import com.blamejared.crafttweaker.api.fluid.IFluidStack;
+import com.blamejared.crafttweaker.api.fluid.*;
 import com.blamejared.crafttweaker.api.item.IIngredient;
 import com.blamejared.crafttweaker.api.item.IItemStack;
 import com.blamejared.crafttweaker.impl.item.MCWeightedItemStack;
@@ -13,7 +13,7 @@ import net.minecraftforge.fluids.FluidStack;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.stream.*;
 
 public class CRTRecipe {
 
@@ -39,16 +39,10 @@ public class CRTRecipe {
         this.inputItems = Arrays.stream(ingredient).map(IIngredient::asVanillaIngredient).collect(Collectors.toList());
         return this;
     }
-
-    public CRTRecipe input(FluidStack... ingredient) {
-
-        this.inputFluids = Arrays.stream(ingredient).map(FluidIngredient::of).collect(Collectors.toList());
-        return this;
-    }
-
-    public CRTRecipe input(IFluidStack... ingredient) {
-
-        this.inputFluids = Arrays.stream(ingredient).map(IFluidStack::getInternal).map(FluidIngredient::of).collect(Collectors.toList());
+    
+    public CRTRecipe input(CTFluidIngredient... ingredient) {
+        
+        this.inputFluids = Arrays.stream(ingredient).map(CRTHelper::mapFluidIngredient).collect(Collectors.toList());
         return this;
     }
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -78,3 +78,10 @@ mandatory = true
 versionRange = "[1.3,1.4]"
 ordering = "AFTER"
 side = "BOTH"
+
+[[dependencies.thermal_foundation]]
+modId = "crafttweaker"
+mandatory = false
+versionRange = "[7.1.2.414,)"
+ordering = "NONE"
+side = "BOTH"


### PR DESCRIPTION
Requires #3 to be merged first.

This is not a breaking change, and all existing scripts should continue to work.